### PR TITLE
Fix Vite JSX parsing

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   esbuild: {
     loader: 'jsx',
-    include: /\.js$/,
+    include: /\.[jt]sx?$/,
   },
   define: {
     'process.env': {


### PR DESCRIPTION
## Summary
- fix jsx loader include pattern in `vite.config.js`

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1c2ec1c832c9c724b942c1b7e50